### PR TITLE
Minor fixes before first run of CPU computations

### DIFF
--- a/cudampilib/cudampilib.c
+++ b/cudampilib/cudampilib.c
@@ -356,7 +356,6 @@ void __cudampi__initializeMPI(int argc, char **argv) {
     fclose(filep);
   }
 
-// TODO also consider cpu devices
   // compute the total device count
   __cudampi_totalgpudevicecount = 0;
   for (i = 0; i < __cudampi__MPIproccount; i++) {
@@ -381,8 +380,6 @@ void __cudampi__initializeMPI(int argc, char **argv) {
     exit(-1); // we could exit in a nicer way! TBD
   }
 
-
-// TODO also consider cpu devices
   __cudampi_targetMPIrankfordevice = (int *)malloc(__cudampi_totaldevicecount * sizeof(int));
   if (!__cudampi_targetMPIrankfordevice) {
     printf("\nNot enough memory");
@@ -393,8 +390,6 @@ void __cudampi__initializeMPI(int argc, char **argv) {
   int currentGPU = 0;
   // now initialize values device by device
   for (i = 0; i < __cudampi_totalgpudevicecount; i++) {
-
-  // TODO also consider cpu devices
     __cudampi_targetGPUfordevice[i] = currentGPU;
     __cudampi_targetMPIrankfordevice[i] = currentrank;
 
@@ -412,8 +407,6 @@ void __cudampi__initializeMPI(int argc, char **argv) {
 
   currentrank = 0;
   for (i = __cudampi_totalgpudevicecount; i < __cudampi_totaldevicecount; i++) {
-
-    // TODO also consider cpu devices
     __cudampi_targetGPUfordevice[i] = -1;
     __cudampi__devicepower[i] = -1; // initial value
     __cudampi__deviceenabled[i] = 1;
@@ -747,7 +740,7 @@ cudaError_t __cudampi__cudaSetDevice(int device) {
 
 int __cudampi__isCpu()
 {
-  // TODO
+  // TODO ?
   return __cudampi__currentDevice  >= __cudampi_totalgpudevicecount;
 }
 

--- a/cudampilib/cudampilib.c
+++ b/cudampilib/cudampilib.c
@@ -410,12 +410,13 @@ void __cudampi__initializeMPI(int argc, char **argv) {
     __cudampi_targetGPUfordevice[i] = -1;
     __cudampi__devicepower[i] = -1; // initial value
     __cudampi__deviceenabled[i] = 1;
-    while (__cudampi__freeThreadsPerNode[i] <= 0)
+    while (__cudampi__freeThreadsPerNode[currentrank] <= 0)
     {
       // skip all nodes with no free threads;
       currentrank ++;
     }
     __cudampi_targetMPIrankfordevice[i] = currentrank;
+    currentrank ++;
   }
   // initialize current device id to 0 although various threads are expected to have various GPU ids
 
@@ -648,7 +649,7 @@ cudaError_t __cudampi__deviceSynchronize(void) {
 
     int targetrank = __cudampi__gettargetMPIrank(__cudampi__currentDevice);
 
-    int sdata = 1; // if 0 then means do not measure power, if 1 do measure on the slave side
+    int sdata = 0; // if 0 then means do not measure power, if 1 do measure on the slave side
     float energy = -1, power = -1;
     int rsize = sizeof(cudaError_t) + sizeof(float);
     unsigned char rdata[rsize];


### PR DESCRIPTION
This PR is based on #25 

### Tested:

**No CPU:**
```
On node 0 using 1 GPUs.
On node 0 using 0 CPU threads.
On node 1 using 1 GPUs.
On node 1 using 0 CPU threads.
On node 2 using 1 GPUs.
On node 2 using 0 CPU threads.
On node 3 using 1 GPUs.
On node 3 using 0 CPU threads.
On node 4 using 1 GPUs.
On node 4 using 0 CPU threads.
Main elapsed time=5.747482
Total elapsed time=6.849168
```

**With CPU:**
```
On node 0 using 1 GPUs.
On node 0 using 0 CPU threads.
On node 1 using 1 GPUs.
On node 1 using 23 CPU threads.
On node 2 using 1 GPUs.
On node 2 using 23 CPU threads.
On node 3 using 1 GPUs.
On node 3 using 23 CPU threads.
On node 4 using 1 GPUs.
On node 4 using 23 CPU threads.
Main elapsed time=5.420811
Total elapsed time=6.517158
```