### PR TITLE
Add unified functions for stream handling

### DIFF
--- a/cudampilib/apps/patternsearch/app-streams-patternsearch.c
+++ b/cudampilib/apps/patternsearch/app-streams-patternsearch.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
 
         __cudampi__cudaMemcpyAsync(devPtra, vectora + mycounter, (batchsize + PATTERNLENGTH) * sizeof(char), cudaMemcpyHostToDevice, stream1);
 
-        __cudampi__kernelinstream(devPtr, stream1);
+        __cudampi__cudaKernelInStream(devPtr, stream1);
 
         __cudampi__cudaMemcpyAsync(vectorc + mycounter, devPtrc, batchsize * sizeof(char), cudaMemcpyDeviceToHost, stream1);
       }
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
 
             __cudampi__cudaMemcpyAsync(devPtra2, vectora + mycounter, (batchsize + PATTERNLENGTH) * sizeof(char), cudaMemcpyHostToDevice, stream2);
 
-            __cudampi__kernelinstream(devPtr2, stream2);
+            __cudampi__cudaKernelInStream(devPtr2, stream2);
 
             __cudampi__cudaMemcpyAsync(vectorc + mycounter, devPtrc2, batchsize * sizeof(char), cudaMemcpyDeviceToHost, stream2);
           }

--- a/cudampilib/apps/vecadd/app-streams-vecadd.c
+++ b/cudampilib/apps/vecadd/app-streams-vecadd.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
         __cudampi__cudaMemcpyAsync(devPtra, vectora + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream1);
         __cudampi__cudaMemcpyAsync(devPtrb, vectorb + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream1);
 
-        __cudampi__kernelinstream(devPtr, stream1);
+        __cudampi__cudaKernelInStream(devPtr, stream1);
 
         __cudampi__cudaMemcpyAsync(vectorc + mycounter, devPtrc, batchsize * sizeof(double), cudaMemcpyDeviceToHost, stream1);
       }
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
             __cudampi__cudaMemcpyAsync(devPtra2, vectora + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream2);
             __cudampi__cudaMemcpyAsync(devPtrb2, vectorb + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream2);
 
-            __cudampi__kernelinstream(devPtr2, stream2);
+            __cudampi__cudaKernelInStream(devPtr2, stream2);
             __cudampi__cudaMemcpyAsync(vectorc + mycounter, devPtrc2, batchsize * sizeof(double), cudaMemcpyDeviceToHost, stream2);
           }
         }

--- a/cudampilib/apps/vecmaxdiv/app-streams-vecmaxdiv.c
+++ b/cudampilib/apps/vecmaxdiv/app-streams-vecmaxdiv.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
         __cudampi__cudaMemcpyAsync(devPtra, vectora + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream1);
         __cudampi__cudaMemcpyAsync(devPtrb, vectorb + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream1);
 
-        __cudampi__kernelinstream(devPtr, stream1);
+        __cudampi__cudaKernelInStream(devPtr, stream1);
 
         __cudampi__cudaMemcpyAsync(vectorc + mycounter, devPtrc, batchsize * sizeof(double), cudaMemcpyDeviceToHost, stream1);
       }
@@ -183,7 +183,7 @@ int main(int argc, char **argv) {
             __cudampi__cudaMemcpyAsync(devPtra2, vectora + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream2);
             __cudampi__cudaMemcpyAsync(devPtrb2, vectorb + mycounter, batchsize * sizeof(double), cudaMemcpyHostToDevice, stream2);
 
-            __cudampi__kernelinstream(devPtr2, stream2);
+            __cudampi__cudaKernelInStream(devPtr2, stream2);
 
             __cudampi__cudaMemcpyAsync(vectorc + mycounter, devPtrc2, batchsize * sizeof(double), cudaMemcpyDeviceToHost, stream2);
           }

--- a/cudampilib/compile
+++ b/cudampilib/compile
@@ -11,7 +11,7 @@ VECMAXDIV_DIR="vecmaxdiv"
 mkdir -p $BUILD_DIR
 
 gcc -c cudampicommon.c -I/usr/local/cuda/include -Iinclude -o $BUILD_DIR/cudampicommon.o
-mpicc -c cudampilib.c -I/usr/local/cuda/include -Iinclude -o $BUILD_DIR/cudampilib.o 
+mpicc -c cudampilib.c -I/usr/local/cuda/include -Iinclude -o $BUILD_DIR/cudampilib.o  -DALLOW_CPU_STREAMS
 #nvcc -c $APPS_DIR/$APP_DIR/appkernel.cu -o $BUILD_DIR/appkernel.o
 #nvcc -c $APPS_DIR/$VECMAXDIV_DIR/appkernelvecmaxdiv.cu -o $BUILD_DIR/appkernelvecmaxdiv.o -Iinclude
 #nvcc -c $APPS_DIR/$VECADD_DIR/appkernelvecadd.cu -o $BUILD_DIR/appkernelvecadd.o -Iinclude
@@ -29,7 +29,7 @@ mpicc -fopenmp -o $BUILD_DIR/cudampislave-collatz cudampislave.c $BUILD_DIR/cpuk
 #mpicc -fopenmp -o $BUILD_DIR/app $APPS_DIR/$APP_DIR/app.c $BUILD_DIR/appkernel.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++
 #mpicc -fopenmp -o $BUILD_DIR/app-streams-vecmaxdiv $APPS_DIR/$VECMAXDIV_DIR/app-streams-vecmaxdiv.c $BUILD_DIR/appkernelvecmaxdiv.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++
 #mpicc -fopenmp -o $BUILD_DIR/app-streams-vecadd $APPS_DIR/$VECADD_DIR/app-streams-vecadd.c $BUILD_DIR/appkernelvecadd.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++
-mpicc -fopenmp -o $BUILD_DIR/app-streams-collatz $APPS_DIR/$COLLATZ_DIR/app-streams-collatz.c $BUILD_DIR/cpukernelcollatz.o $BUILD_DIR/appkernelcollatz.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++ -lm
+mpicc -fopenmp -o $BUILD_DIR/app-streams-collatz $APPS_DIR/$COLLATZ_DIR/app-streams-collatz.c $BUILD_DIR/cpukernelcollatz.o $BUILD_DIR/appkernelcollatz.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++ -lm -DALLOW_CPU_STREAMS
 #mpicc -fopenmp -o $BUILD_DIR/app-streams-patternsearch $APPS_DIR/$PATTERSEARCH_DIR/app-streams-patternsearch.c $BUILD_DIR/appkernelpatternsearch.o $BUILD_DIR/cudampilib.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++
 
 echo "Build complete. Executables and object files are in '$BUILD_DIR'."

--- a/cudampilib/include/cudampilib.h
+++ b/cudampilib/include/cudampilib.h
@@ -62,7 +62,7 @@ cudaError_t __cudampi__cpuMemcpyAsync(void *dst, const void *src, size_t count, 
 
 void __cudampi__kernel(void *devPtr);
 
-void __cudampi__kernelinstream(void *devPtr, cudaStream_t stream);
+void __cudampi__cudaKernelInStream(void *devPtr, cudaStream_t stream);
 
 void __cudampi__cpuKernel(void *devPtr);
 
@@ -75,3 +75,15 @@ cudaError_t  __cudampi__getDeviceCount (int *count);
 cudaError_t __cudampi__cudaStreamCreate(cudaStream_t *pStream);
 
 cudaError_t __cudampi__cudaStreamDestroy(cudaStream_t stream);
+
+#ifdef ALLOW_CPU_STREAMS
+cudaError_t __cudampi__streamCreate(cudaStream_t *stream);
+
+cudaError_t __cudampi__streamDestroy(cudaStream_t stream);
+
+cudaError_t __cudampi__memcpyAsync(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind, cudaStream_t stream);
+
+cudaError_t __cudampi__memcpy(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind, cudaStream_t stream);
+
+void __cudampi__kernelInStream(void *devPtr, cudaStream_t stream);
+#endif


### PR DESCRIPTION
CPU streams don't really make sense as much as they do for GPU since only data passing is done on connection between master and slave (and not also on slave from host to device). Only possible usage would be oversubscribing, but it would need to be tested if it actually increases performance of tested applications. 

This PR implements functions that unify processing between CPU and GPU by providing empty implementations for cpu stream processing. In scenario when this unified approach is used, CPU will receive twice as much data packets at once. This unified approach can be enabled with compilation flag `ALLOW_CPU_STREAMS`.