### PR TITLE
Fix bug that disabled parallel execution in CPU kernels

### DIFF
--- a/cudampilib/apps/collatz/cpukernelcollatz.c
+++ b/cudampilib/apps/collatz/cpukernelcollatz.c
@@ -40,21 +40,19 @@ void appkernel(void *devPtr, int num_elements, int num_threads)
   double *devPtrc = (double *)(((void **)devPtr)[1]);
 
   #pragma omp parallel for num_threads(num_threads)
+  for (long my_index = 0; my_index < num_elements; my_index++) 
   {
-    for (long my_index = 0; my_index < num_elements; my_index++) 
-    {
-      unsigned long start = devPtra[my_index];
-      unsigned long counter = 0;
+    unsigned long start = devPtra[my_index];
+    unsigned long counter = 0;
 
-      if (isprime(start)) 
+    if (isprime(start)) 
+    {
+      for (; (start > 1); counter++) 
       {
-        for (; (start > 1); counter++) 
-        {
-          start = (start % 2) ? (3 * start + 1) : (start / 2);
-        }
+        start = (start % 2) ? (3 * start + 1) : (start / 2);
       }
-      devPtrc[my_index] = counter;
     }
+    devPtrc[my_index] = counter;
   }
 }
 

--- a/cudampilib/apps/patternsearch/cpukernelpatternsearch.c
+++ b/cudampilib/apps/patternsearch/cpukernelpatternsearch.c
@@ -27,27 +27,25 @@ void appkernel(void *devPtr, int num_elements, int num_threads)
   char *devPtrc = (char *)(((void **)devPtr)[1]);
 
   #pragma omp parallel for num_threads(num_threads)
+  for (long my_index = 0; my_index < num_elements; my_index++)
   {
-    for (long my_index = 0; my_index < num_elements; my_index++)
-    {
-        int i, j;
-        char ok;
+      int i, j;
+      char ok;
 
-        devPtrc[my_index] = 0;
+      devPtrc[my_index] = 0;
 
-        for (i = 0; i < PATTERNCOUNT; i++) 
-        {
-            ok = 1;
-            for (j = 0; j < PATTERNLENGTH; j++) 
-            {
-                if (devPtra[my_index + j] != pattern[i][j])
-                {
-                    ok = 0;
-                }
-            }
-            devPtrc[my_index] += ok;
-        }
-    }
+      for (i = 0; i < PATTERNCOUNT; i++) 
+      {
+          ok = 1;
+          for (j = 0; j < PATTERNLENGTH; j++) 
+          {
+              if (devPtra[my_index + j] != pattern[i][j])
+              {
+                  ok = 0;
+              }
+          }
+          devPtrc[my_index] += ok;
+      }
   }
 }
 

--- a/cudampilib/apps/vecadd/cpukernelvecadd.c
+++ b/cudampilib/apps/vecadd/cpukernelvecadd.c
@@ -26,11 +26,9 @@ void appkernel(void *devPtr, int num_elements, int num_threads)
     double *devPtrc = (double *)(((void **)devPtr)[2]);
 
     #pragma omp parallel for num_threads(num_threads)
+    for (long my_index = 0; my_index < num_elements; my_index++) 
     {
-        for (long my_index = 0; my_index < num_elements; my_index++) 
-        {
-            devPtrc[my_index] = devPtra[my_index] / 2 + devPtrb[my_index] / 3;
-        }
+        devPtrc[my_index] = devPtra[my_index] / 2 + devPtrb[my_index] / 3;
     }
 }
 

--- a/cudampilib/apps/vecmaxdiv/cpukernelvecmaxdiv.c
+++ b/cudampilib/apps/vecmaxdiv/cpukernelvecmaxdiv.c
@@ -27,38 +27,36 @@ void appkernel(void *devPtr, int num_elements, int num_threads)
   double *devPtrc = (double *)(((void **)devPtr)[2]);
 
   #pragma omp parallel for num_threads(num_threads)
-  {
-    for (long my_index = 0 ; my_index < num_elements; my_index++)
+for (long my_index = 0 ; my_index < num_elements; my_index++)
+{
+    long i;
+    long result = 1;
+    long max = sqrt(devPtra[my_index]);
+    long elem = devPtra[my_index];
+    for (i = 2; i < max; i++) 
     {
-        long i;
-        long result = 1;
-        long max = sqrt(devPtra[my_index]);
-        long elem = devPtra[my_index];
-        for (i = 2; i < max; i++) 
+        if (!(elem % i)) 
         {
-            if (!(elem % i)) 
+            if (i >= result) 
             {
-                if (i >= result) 
-                {
-                    result = i;
-                }
+                result = i;
             }
         }
-        max = sqrt(devPtrb[my_index]);
-        elem = devPtrb[my_index];
-        for (i = 2; i < max; i++) 
-        {
-            if (!(elem % i)) 
-            {
-                if (i >= result) 
-                {
-                    result = i;
-                }
-            }
-        }
-        devPtrc[my_index] = result;
     }
-  }
+    max = sqrt(devPtrb[my_index]);
+    elem = devPtrb[my_index];
+    for (i = 2; i < max; i++) 
+    {
+        if (!(elem % i)) 
+        {
+            if (i >= result) 
+            {
+                result = i;
+            }
+        }
+    }
+    devPtrc[my_index] = result;
+}
 }
 
 extern void launchcpukernel(void *devPtr, int num_threads) 

--- a/cudampilib/compile
+++ b/cudampilib/compile
@@ -10,7 +10,7 @@ VECMAXDIV_DIR="vecmaxdiv"
 
 mkdir -p $BUILD_DIR
 
-gcc -c cudampicommon.c -I/usr/local/cuda/include -Iinclude -o $BUILD_DIR/cudampicommon.o
+gcc -fopenmp -c cudampicommon.c -I/usr/local/cuda/include -Iinclude -o $BUILD_DIR/cudampicommon.o
 mpicc -c cudampilib.c -I/usr/local/cuda/include -Iinclude -o $BUILD_DIR/cudampilib.o 
 
 #nvcc -c $APPS_DIR/$APP_DIR/appkernel.cu -o $BUILD_DIR/appkernel.o
@@ -20,10 +20,10 @@ nvcc -c $APPS_DIR/$COLLATZ_DIR/appkernelcollatz.cu -o $BUILD_DIR/appkernelcollat
 nvcc -c $APPS_DIR/$PATTERNSEARCH_DIR/appkernelpatternsearch.cu -o $BUILD_DIR/appkernelpatternsearch.o -Iinclude
 
 
-gcc -c $APPS_DIR/$COLLATZ_DIR/cpukernelcollatz.c -Iinclude -o $BUILD_DIR/cpukernelcollatz.o
-gcc -c $APPS_DIR/$VECADD_DIR/cpukernelvecadd.c -Iinclude -o $BUILD_DIR/cpukernelvecadd.o
-gcc -c $APPS_DIR/$VECMAXDIV_DIR/cpukernelvecmaxdiv.c -Iinclude -o $BUILD_DIR/cpukernelvecmaxdiv.o -lm
-gcc -c $APPS_DIR/$PATTERNSEARCH_DIR/cpukernelpatternsearch.c -Iinclude -o $BUILD_DIR/cpukernelpatternsearch.o
+gcc -fopenmp -c $APPS_DIR/$COLLATZ_DIR/cpukernelcollatz.c -Iinclude -o $BUILD_DIR/cpukernelcollatz.o
+gcc -fopenmp -c $APPS_DIR/$VECADD_DIR/cpukernelvecadd.c -Iinclude -o $BUILD_DIR/cpukernelvecadd.o
+gcc -fopenmp -c $APPS_DIR/$VECMAXDIV_DIR/cpukernelvecmaxdiv.c -Iinclude -o $BUILD_DIR/cpukernelvecmaxdiv.o -lm
+gcc -fopenmp -c $APPS_DIR/$PATTERNSEARCH_DIR/cpukernelpatternsearch.c -Iinclude -o $BUILD_DIR/cpukernelpatternsearch.o
 
 #mpicc -fopenmp -o $BUILD_DIR/cudampislave cudampislave.c $BUILD_DIR/appkernel.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++
 mpicc -fopenmp -o $BUILD_DIR/cudampislave-vecmaxdiv cudampislave.c $BUILD_DIR/cpukernelvecmaxdiv.o $BUILD_DIR/appkernelvecmaxdiv.o $BUILD_DIR/cudampicommon.o -I/usr/local/cuda/include -Iinclude -L/usr/local/cuda/lib64 -lcudart -lstdc++ -lm


### PR DESCRIPTION
Fix for bug where because openmp was not included to kernels during compilation, cpu kernels executed on only one thread.

Just GPU:
```
On node 0 using 1 GPUs.
On node 0 using 0 CPU threads.
On node 1 using 1 GPUs.
On node 1 using 0 CPU threads.
[2024-10-09 23:38:31] [INFO] Main elapsed time=9.945757
```

GPU+CPU Before:
```
On node 0 using 1 GPUs.
On node 0 using 0 CPU threads.
On node 1 using 1 GPUs.
On node 1 using 23 CPU threads.
[2024-10-09 23:39:01] [INFO] Main elapsed time=9.764886
```
GPU+CPU After:
```
On node 0 using 1 GPUs.
On node 0 using 0 CPU threads.
On node 1 using 1 GPUs.
On node 1 using 23 CPU threads.
[2024-10-09 23:41:43] [INFO] Main elapsed time=7.702738
```