### PR TITLE
Add connection check script

### DIFF
--- a/cudampilib/check_connection.sh
+++ b/cudampilib/check_connection.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+prefix="172.20.83"
+
+for i in {201..218}
+do
+    ip="$prefix.$i"
+    
+    ping -c 2 "$ip" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "Host $ip is reachable. Attempting SSH connection..."
+        
+        ssh -o "StrictHostKeyChecking=no" -o "BatchMode=yes" -o "ConnectTimeout=5" "$ip" exit
+        
+        if [ $? -eq 0 ]; then
+            echo "Successfully connected to $ip and exited."
+        else
+            echo "Failed to connect to $ip or SSH timed out."
+        fi
+    else
+        echo "Host $ip is unreachable."
+    fi
+done


### PR DESCRIPTION
Run it before you use new `run-app` script from #61 since machines in lab are often broken.
It also configure `known_hosts` automatically so when you run on multiple machines you don't need to manually set ssh fingerprint.

![obraz](https://github.com/user-attachments/assets/3fc5e015-7e33-4c6d-8a26-b153baa2f464)
